### PR TITLE
Add Xcode 9 support

### DIFF
--- a/sources/main.swift
+++ b/sources/main.swift
@@ -17,8 +17,12 @@ guard let command = commands[flag] else {
 
 switch command(Array(arguments)) {
     case .success(let coordinate) where coordinate.isValid:
-        print("Setting location to \(coordinate.latitude) \(coordinate.longitude)")
-        postNotification(for: coordinate)
+        do {
+            postNotification(for: coordinate, to: try getBootedSimulators())
+            print("Setting location to \(coordinate.latitude) \(coordinate.longitude)")
+        } catch let error as SimulatorFetchError {
+            exitWithUsage(error: error.rawValue)
+        }
     case .success(let coordinate):
         exitWithUsage(error: "Coordinate: \(coordinate) is invalid")
     case .failure(let error):

--- a/sources/notification.swift
+++ b/sources/notification.swift
@@ -3,10 +3,11 @@ import Foundation
 
 private let kNotificationName = "com.apple.iphonesimulator.simulateLocation"
 
-func postNotification(for coordinate: CLLocationCoordinate2D) {
+func postNotification(for coordinate: CLLocationCoordinate2D, to simulators: [String]) {
     let userInfo: [AnyHashable: Any] = [
         "simulateLocationLatitude": coordinate.latitude,
         "simulateLocationLongitude": coordinate.longitude,
+        "simulateLocationDevices": simulators,
     ]
 
     let notification = Notification(name: Notification.Name(rawValue: kNotificationName), object: nil,

--- a/sources/simulators.swift
+++ b/sources/simulators.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+private let kBootedUDIDRegex = "^    [^(]*\\(([^\\)]*)\\) \\(Booted\\)$"
+
+enum SimulatorFetchError: String, Error {
+    case simctlFailed = "Running `simctl list` failed"
+    case failedToReadOutput = "Failed to read output from simctl"
+    case noBootedSimulators = "No simulators are currently booted"
+}
+
+func getBootedSimulators() throws -> [String] {
+    let task = Process()
+    task.launchPath = "/usr/bin/xcrun"
+    task.arguments = ["simctl", "list", "devices"]
+
+    let pipe = Pipe()
+    task.standardOutput = pipe
+
+    task.launch()
+
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    task.waitUntilExit()
+    pipe.fileHandleForReading.closeFile()
+
+    if task.terminationStatus != 0 {
+        throw SimulatorFetchError.simctlFailed
+    }
+
+    guard let output = String(data: data, encoding: .utf8) else {
+        throw SimulatorFetchError.failedToReadOutput
+    }
+
+    let nsString = output as NSString
+    let regex = try! NSRegularExpression(pattern: kBootedUDIDRegex, options: .anchorsMatchLines)
+    let matches = regex.matches(in: output, options: [],
+                                range: NSRange(location: 0, length: nsString.length))
+
+    if matches.isEmpty {
+        throw SimulatorFetchError.noBootedSimulators
+    }
+
+    return matches.map { nsString.substring(with: $0.rangeAt(1)) }
+}


### PR DESCRIPTION
With the large number of simulator changes in Xcode 9 came a change
where the notification we're hijacking needs to send along the UDIDs of
the simulators where the change should take effect. This is because you
can have multiple running simulators with different locations.

To do this, for now, we're just reading the output of `simctl list` and
sending all booted UDIDs along.