### PR TITLE
Set location for a single simulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 set-simulator-location
+.DS_Store

--- a/sources/main.swift
+++ b/sources/main.swift
@@ -5,16 +5,19 @@ var arguments = CommandLine.arguments.dropFirst()
 
 enum DeviceMode
 {
-    case singleDevice
+    case singleDevice(device: String)
     case bootedDevices
 }
-
 
 // default
 var deviceMode: DeviceMode = .bootedDevices
 
-if arguments.contains("-d") {
-    deviceMode = .singleDevice
+if let argumentIndex = arguments.index(of: "-d") {
+    let deviceIndex = arguments.index(after: argumentIndex)
+    let device = arguments[deviceIndex]
+    arguments.remove(at: deviceIndex)
+    arguments.remove(at: argumentIndex)
+    deviceMode = .singleDevice(device)
 }
 
 guard let flag = arguments.popFirst() else {
@@ -38,8 +41,8 @@ switch command(Array(arguments)) {
             {
             case .bootedDevices:
                 postNotification(for: coordinate, to: try getBootedSimulators())
-            case .singleDevice:
-                switch try getDeviceUdid(from: Array(arguments))
+            case .singleDevice(let device):
+                switch try getDeviceUdid(name: device)
                 {
                 case .success(let simulator):
                     postNotification(for: coordinate, to: [simulator])

--- a/sources/main.swift
+++ b/sources/main.swift
@@ -3,8 +3,7 @@ import Foundation
 
 var arguments = CommandLine.arguments.dropFirst()
 
-enum DeviceMode
-{
+enum DeviceMode {
     case singleDevice(device: String)
     case bootedDevices
 }
@@ -14,14 +13,12 @@ var deviceMode: DeviceMode = .bootedDevices
 
 if let argumentIndex = arguments.index(of: "-d") {
     let deviceIndex = arguments.index(after: argumentIndex)
-    if deviceIndex != arguments.endIndex
-    {
+    if deviceIndex != arguments.endIndex {
         let device = arguments[deviceIndex]
         arguments.remove(at: deviceIndex)
         arguments.remove(at: argumentIndex)
         deviceMode = .singleDevice(device: device)
-    }
-    else {
+    } else {
         exitWithUsage()
     }
 }
@@ -33,7 +30,7 @@ guard let flag = arguments.popFirst() else {
 
 let commands = [
     "-c": coordinate,
-    "-q": findLocation
+    "-q": findLocation,
 ]
 
 guard let command = commands[flag] else {
@@ -43,13 +40,11 @@ guard let command = commands[flag] else {
 switch command(Array(arguments)) {
     case .success(let coordinate) where coordinate.isValid:
         do {
-            switch deviceMode
-            {
+            switch deviceMode {
             case .bootedDevices:
                 postNotification(for: coordinate, to: try getBootedSimulators())
             case .singleDevice(let device):
-                switch try getDeviceUdid(name: device)
-                {
+                switch try getDeviceUdid(name: device) {
                 case .success(let simulator):
                     postNotification(for: coordinate, to: [simulator])
                 case .failure(let error):

--- a/sources/main.swift
+++ b/sources/main.swift
@@ -14,10 +14,16 @@ var deviceMode: DeviceMode = .bootedDevices
 
 if let argumentIndex = arguments.index(of: "-d") {
     let deviceIndex = arguments.index(after: argumentIndex)
-    let device = arguments[deviceIndex]
-    arguments.remove(at: deviceIndex)
-    arguments.remove(at: argumentIndex)
-    deviceMode = .singleDevice(device: device)
+    if deviceIndex != arguments.endIndex
+    {
+        let device = arguments[deviceIndex]
+        arguments.remove(at: deviceIndex)
+        arguments.remove(at: argumentIndex)
+        deviceMode = .singleDevice(device: device)
+    }
+    else {
+        exitWithUsage()
+    }
 }
 
 guard let flag = arguments.popFirst() else {

--- a/sources/main.swift
+++ b/sources/main.swift
@@ -17,7 +17,7 @@ if let argumentIndex = arguments.index(of: "-d") {
     let device = arguments[deviceIndex]
     arguments.remove(at: deviceIndex)
     arguments.remove(at: argumentIndex)
-    deviceMode = .singleDevice(device)
+    deviceMode = .singleDevice(device: device)
 }
 
 guard let flag = arguments.popFirst() else {

--- a/sources/main.swift
+++ b/sources/main.swift
@@ -2,13 +2,29 @@ import CoreLocation
 import Foundation
 
 var arguments = CommandLine.arguments.dropFirst()
+
+enum DeviceMode
+{
+    case singleDevice
+    case bootedDevices
+}
+
+
+// default
+var deviceMode: DeviceMode = .bootedDevices
+
+if arguments.contains("-d") {
+    deviceMode = .singleDevice
+}
+
 guard let flag = arguments.popFirst() else {
     exitWithUsage()
 }
 
+
 let commands = [
     "-c": coordinate,
-    "-q": findLocation,
+    "-q": findLocation
 ]
 
 guard let command = commands[flag] else {
@@ -18,7 +34,21 @@ guard let command = commands[flag] else {
 switch command(Array(arguments)) {
     case .success(let coordinate) where coordinate.isValid:
         do {
-            postNotification(for: coordinate, to: try getBootedSimulators())
+            switch deviceMode
+            {
+            case .bootedDevices:
+                postNotification(for: coordinate, to: try getBootedSimulators())
+            case .singleDevice:
+                switch try getDeviceUdid(from: Array(arguments))
+                {
+                case .success(let simulator):
+                    postNotification(for: coordinate, to: [simulator])
+                case .failure(let error):
+                    exitWithUsage(error: error)
+                }
+
+            }
+
             print("Setting location to \(coordinate.latitude) \(coordinate.longitude)")
         } catch let error as SimulatorFetchError {
             exitWithUsage(error: error.rawValue)

--- a/sources/simulators.swift
+++ b/sources/simulators.swift
@@ -6,10 +6,8 @@ enum SimulatorFetchError: String, Error {
     case noBootedSimulators = "No simulators are currently booted"
 }
 
-struct Simulator
-{
-    enum State : String
-    {
+struct Simulator {
+    enum State : String {
         case shutdown = "Shutdown"
         case booted = "Booted"
     }
@@ -19,8 +17,7 @@ struct Simulator
     var state: State
 }
 
-func getDeviceUdid(name: String) throws -> Result<String>
-{
+func getDeviceUdid(name: String) throws -> Result<String> {
     let simulators: [Simulator] = try getSimulators().filter { $0.name == name }
 
     guard let simulator = simulators.first else {
@@ -30,8 +27,7 @@ func getDeviceUdid(name: String) throws -> Result<String>
     return .success(simulator.udid)
 }
 
-func getBootedSimulators() throws -> [String]
-{
+func getBootedSimulators() throws -> [String] {
     let simulators = try getSimulators()
     let bootedSimulators = simulators.filter { $0.state == .booted }
                                     .map { $0.udid }
@@ -65,12 +61,9 @@ func getSimulators() throws -> [Simulator] {
     let devices = json["devices"] as? [String: [[String: String]]] ?? [:]
 
     var simulators = [Simulator]()
-    for topName in devices.keys
-    {
-        if let deviceTypes = devices[topName]
-        {
-            for typeDict in deviceTypes
-            {
+    for topName in devices.keys {
+        if let deviceTypes = devices[topName] {
+            for typeDict in deviceTypes {
                 guard let udid = typeDict["udid"],
                     let name = typeDict["name"],
                     let stateString = typeDict["state"],

--- a/sources/simulators.swift
+++ b/sources/simulators.swift
@@ -19,16 +19,9 @@ struct Simulator
     var state: State
 }
 
-func getDeviceUdid(from arguments: [String]) throws -> Result<String>
+func getDeviceUdid(name: String) throws -> Result<String>
 {
-    guard let argumentIndex = arguments.index(of: "-d") else {
-        return .failure("No arguments passed for device search")
-    }
-
-    let deviceIndex = arguments.index(after: argumentIndex)
-    let device = arguments[deviceIndex]
-
-    let simulators: [Simulator] = try getSimulators().filter { $0.name == device }
+    let simulators: [Simulator] = try getSimulators().filter { $0.name == name }
 
     guard let simulator = simulators.first else {
         return .failure("No simulators found by that name")

--- a/sources/simulators.swift
+++ b/sources/simulators.swift
@@ -18,9 +18,7 @@ struct Simulator {
 }
 
 func getDeviceUdid(name: String) throws -> Result<String> {
-    let simulators: [Simulator] = try getSimulators().filter { $0.name == name }
-
-    guard let simulator = simulators.first else {
+    guard let simulator: Simulator = try getSimulators().first(where: { $0.name == name }) else {
         return .failure("No simulators found by that name")
     }
 

--- a/sources/simulators.swift
+++ b/sources/simulators.swift
@@ -6,7 +6,48 @@ enum SimulatorFetchError: String, Error {
     case noBootedSimulators = "No simulators are currently booted"
 }
 
-func getBootedSimulators() throws -> [String] {
+struct Simulator
+{
+    enum State : String
+    {
+        case shutdown = "Shutdown"
+        case booted = "Booted"
+    }
+
+    var udid: String
+    var name: String
+    var state: State
+}
+
+func getDeviceUdid(from arguments: [String]) throws -> Result<String>
+{
+    guard let argumentIndex = arguments.index(of: "-d") else {
+        return .failure("No arguments passed for device search")
+    }
+
+    let deviceIndex = arguments.index(after: argumentIndex)
+    let device = arguments[deviceIndex]
+
+    let simulators: [Simulator] = try getSimulators().filter { $0.name == device }
+
+    guard let simulator = simulators.first else {
+        return .failure("No simulators found by that name")
+    }
+
+    return .success(simulator.udid)
+}
+
+func getBootedSimulators() throws -> [String]
+{
+    let simulators = try getSimulators()
+    let bootedSimulators = simulators.filter { $0.state == .booted }
+                                    .map { $0.udid }
+
+    return bootedSimulators
+}
+
+
+func getSimulators() throws -> [Simulator] {
     let task = Process()
     task.launchPath = "/usr/bin/xcrun"
     task.arguments = ["simctl", "list", "-j", "devices"]
@@ -29,14 +70,24 @@ func getBootedSimulators() throws -> [String] {
     }
 
     let devices = json["devices"] as? [String: [[String: String]]] ?? [:]
-    let bootedIDs = devices
-        .flatMap { $1 }
-        .filter { $0["state"] == "Booted" }
-        .flatMap { $0["udid"] }
 
-    if bootedIDs.isEmpty {
-        throw SimulatorFetchError.noBootedSimulators
+    var simulators = [Simulator]()
+    for topName in devices.keys
+    {
+        if let deviceTypes = devices[topName]
+        {
+            for typeDict in deviceTypes
+            {
+                guard let udid = typeDict["udid"],
+                    let name = typeDict["name"],
+                    let stateString = typeDict["state"],
+                    let state = Simulator.State(rawValue: stateString) else {
+                        continue
+                }
+                simulators.append(Simulator(udid: udid, name: name, state: state))
+            }
+        }
     }
 
-    return bootedIDs
+    return simulators
 }

--- a/sources/simulators.swift
+++ b/sources/simulators.swift
@@ -61,17 +61,15 @@ func getSimulators() throws -> [Simulator] {
     let devices = json["devices"] as? [String: [[String: String]]] ?? [:]
 
     var simulators = [Simulator]()
-    for topName in devices.keys {
-        if let deviceTypes = devices[topName] {
-            for typeDict in deviceTypes {
-                guard let udid = typeDict["udid"],
-                    let name = typeDict["name"],
-                    let stateString = typeDict["state"],
-                    let state = Simulator.State(rawValue: stateString) else {
-                        continue
-                }
-                simulators.append(Simulator(udid: udid, name: name, state: state))
+    for (_, deviceTypes) in devices {
+        for typeDict in deviceTypes {
+            guard let udid = typeDict["udid"],
+                let name = typeDict["name"],
+                let stateString = typeDict["state"],
+                let state = Simulator.State(rawValue: stateString) else {
+                    continue
             }
+            simulators.append(Simulator(udid: udid, name: name, state: state))
         }
     }
 

--- a/sources/stderr.swift
+++ b/sources/stderr.swift
@@ -13,6 +13,6 @@ func exitWithUsage(error: String? = nil) -> Never {
         print(error, terminator: "\n\n", to: &stderrStream)
     }
 
-    print("Usage set-simulator-location [-c 0 0|-q San Francisco] [-d 'Simulator Device Name']", to: &stderrStream)
+    print("Usage: set-simulator-location [-c 0 0|-q San Francisco] [-d 'Simulator Device Name']", to: &stderrStream)
     exit(EXIT_FAILURE)
 }

--- a/sources/stderr.swift
+++ b/sources/stderr.swift
@@ -13,6 +13,6 @@ func exitWithUsage(error: String? = nil) -> Never {
         print(error, terminator: "\n\n", to: &stderrStream)
     }
 
-    print("Usage set-simulator-location [-c 0 0|-q San Francisco]", to: &stderrStream)
+    print("Usage set-simulator-location [-c 0 0|-q San Francisco] [-d 'Simulator Device Name']", to: &stderrStream)
     exit(EXIT_FAILURE)
 }


### PR DESCRIPTION
This leaves default behavior of 'all booted simulators' intact but adds an additional option to only change the location for one simulator.