### PR TITLE
Allow changing of a single simulator's location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.DS_Store
 set-simulator-location

--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ Or using place search:
 $ set-simulator-location -q Lyft HQ San Francisco
 ```
 
+By default the location is set on all booted simulators. If you'd like
+to change it for only one of the booted simulators you can pass `-s`
+followed by the simulator's display name:
+
+```sh
+$ set-simulator-location -q Lyft HQ San Francisco -s iPhone X
+```
+
+NOTE: If you have multiple booted simulators with the same name, the
+location will be set on all of them.
+
 ## Installation
 
 With [`homebrew`](http://brew.sh/):

--- a/sources/errors.swift
+++ b/sources/errors.swift
@@ -1,0 +1,19 @@
+enum SimulatorFetchError: Error, CustomStringConvertible {
+    case simctlFailed
+    case failedToReadOutput
+    case noBootedSimulators
+    case noMatchingSimulators(name: String)
+
+    var description: String {
+        switch self {
+        case .simctlFailed:
+            return "Running `simctl list` failed"
+        case .failedToReadOutput:
+            return "Failed to read output from simctl"
+        case .noBootedSimulators:
+            return "No simulators are currently booted"
+        case .noMatchingSimulators(let name):
+            return "No booted simulators named '\(name)'"
+        }
+    }
+}

--- a/sources/main.swift
+++ b/sources/main.swift
@@ -2,6 +2,19 @@ import CoreLocation
 import Foundation
 
 var arguments = CommandLine.arguments.dropFirst()
+
+var deviceName: String?
+if let argumentIndex = arguments.index(of: "-s") {
+    let device = arguments.suffix(from: argumentIndex).dropFirst().joined(separator: " ")
+    if device.isEmpty {
+        exitWithUsage()
+    } else {
+        deviceName = device
+    }
+
+    arguments = arguments.prefix(upTo: argumentIndex)
+}
+
 guard let flag = arguments.popFirst() else {
     exitWithUsage()
 }
@@ -18,10 +31,13 @@ guard let command = commands[flag] else {
 switch command(Array(arguments)) {
     case .success(let coordinate) where coordinate.isValid:
         do {
-            postNotification(for: coordinate, to: try getBootedSimulators())
+            let bootedSimulators = try getBootedSimulators()
+            let simulators = try deviceName.map { try getSimulators(named: $0, from: bootedSimulators) }
+                ?? bootedSimulators
+            postNotification(for: coordinate, to: simulators.map { $0.udid })
             print("Setting location to \(coordinate.latitude) \(coordinate.longitude)")
         } catch let error as SimulatorFetchError {
-            exitWithUsage(error: error.rawValue)
+            exitWithUsage(error: error.description)
         }
     case .success(let coordinate):
         exitWithUsage(error: "Coordinate: \(coordinate) is invalid")

--- a/sources/query.swift
+++ b/sources/query.swift
@@ -23,7 +23,7 @@ func findLocation(from arguments: [String]) -> Result<CLLocationCoordinate2D> {
     }
 
     guard let coordinate = placemark.location?.coordinate else {
-        return .failure("No coordinate found for '\(placemark.name)'")
+        return .failure("No coordinate found for '\(placemark.name ?? "")'")
     }
 
     return .success(coordinate)

--- a/sources/stderr.swift
+++ b/sources/stderr.swift
@@ -13,6 +13,6 @@ func exitWithUsage(error: String? = nil) -> Never {
         print(error, terminator: "\n\n", to: &stderrStream)
     }
 
-    print("Usage set-simulator-location [-c 0 0|-q San Francisco]", to: &stderrStream)
+    print("Usage: set-simulator-location [-c 0 0|-q San Francisco] [-s Simulator Name]", to: &stderrStream)
     exit(EXIT_FAILURE)
 }


### PR DESCRIPTION
This allows you to pass a `-s` argument followed by the simulator's
display name in order to set the location of a single simulator, instead
of all booted simulators.