### PR TITLE
Add SwiftPM support for xcodeproj generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+.build
 .DS_Store
+Project.xcodeproj
 set-simulator-location

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,12 @@ archive: $(EXECUTABLE)
 	@shasum -a 256 $(EXECUTABLE)
 	@shasum -a 256 $(ARCHIVE)
 
+.PHONY: xcode
+xcode:
+	swift package generate-xcodeproj \
+		--xcconfig-overrides xcodeproj.xcconfig \
+		--output Project.xcodeproj
+
 .PHONY: clean
 clean:
 	rm -rf $(EXECUTABLE) $(ARCHIVE)

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version:4.0
+import PackageDescription
+
+let package = Package(
+    name: "set-simulator-location",
+    targets: [
+        .target(
+            name: "set-simulator-location",
+            path: "sources"
+        ),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -50,3 +50,9 @@ $ make install
 
 I have submitted [a Radar](http://www.openradar.me/30789939) to have
 this behavior added to `simctl`.
+
+### Development
+
+To work on `set-simulator-location` you can make your changes and run
+`make` to build from the command line. If you'd prefer to work in Xcode
+you can run `make xcode` to generate a project using SwiftPM.

--- a/xcodeproj.xcconfig
+++ b/xcodeproj.xcconfig
@@ -1,0 +1,1 @@
+SUPPORTED_PLATFORMS = macosx


### PR DESCRIPTION
This adds `make xcode` to generate `Project.xcodeproj` for development