### PR TITLE
Reorder failure errors

### DIFF
--- a/sources/query.swift
+++ b/sources/query.swift
@@ -14,16 +14,16 @@ func findLocation(from arguments: [String]) -> Result<CLLocationCoordinate2D> {
     let search = MKLocalSearch(request: request)
     let (response, error) = search.perform()
 
-    if let error = error {
-        return .failure(error.localizedDescription)
-    }
-
     guard let placemark = response?.mapItems.first?.placemark else {
         return .failure("No locations found for '\(query)'")
     }
 
     guard let coordinate = placemark.location?.coordinate else {
         return .failure("No coordinate found for '\(placemark.name ?? "")'")
+    }
+
+    if let error = error {
+        return .failure(error.localizedDescription)
     }
 
     return .success(coordinate)


### PR DESCRIPTION
When there are no locations found for a query, MapKit returns a NSError
instead of an empty array. This resulted in us printing a opaque error.
Now we'll do that last, only if there is an error, but we also found a
place.

Here's an example of a query that currently fails:

Lyft HQ San Francisco