### PR TITLE
Fix for Xcode 10.1

### DIFF
--- a/sources/query.swift
+++ b/sources/query.swift
@@ -8,7 +8,7 @@ func findLocation(from arguments: [String]) -> Result<CLLocationCoordinate2D> {
     }
 
     let query = arguments.joined(separator: " ")
-    let request = MKLocalSearchRequest()
+    let request = MKLocalSearch.Request()
     request.naturalLanguageQuery = query
 
     let search = MKLocalSearch(request: request)
@@ -30,8 +30,8 @@ func findLocation(from arguments: [String]) -> Result<CLLocationCoordinate2D> {
 }
 
 private extension MKLocalSearch {
-    func perform() -> (MKLocalSearchResponse?, Error?) {
-        var result: (MKLocalSearchResponse?, Error?)?
+    func perform() -> (Response?, Error?) {
+        var result: (Response?, Error?)?
 
         self.start { response, error in
             result = (response, error)

--- a/sources/simulators.swift
+++ b/sources/simulators.swift
@@ -10,9 +10,9 @@ struct Simulator {
     let name: String
     let udid: String
 
-    fileprivate init?(dictionary: [String: String]) {
-        guard let state = dictionary["state"].flatMap(State.init), let udid = dictionary["udid"],
-            let name = dictionary["name"] else
+    fileprivate init?(dictionary: [String: Any]) {
+        guard let state = State(rawValue: dictionary["state"] as? String ?? ""),
+            let udid = dictionary["udid"] as? String, let name = dictionary["name"] as? String else
         {
             return nil
         }
@@ -54,7 +54,7 @@ func getBootedSimulators() throws -> [Simulator] {
         throw SimulatorFetchError.failedToReadOutput
     }
 
-    let devices = json["devices"] as? [String: [[String: String]]] ?? [:]
+    let devices = json["devices"] as? [String: [[String: Any]]] ?? [:]
     let bootedSimulators = devices.flatMap { $1 }
         .compactMap(Simulator.init)
         .filter { $0.state == .booted }


### PR DESCRIPTION
Fixes an issue where `set-simulator-location` was failing to initialize its list of Simulators due to non-string values output by the newer version of xcrun shipped with Xcode 10.1. Also updates MapKit references for Swift 4.2.