### PR TITLE
Support passing simulator udid

### DIFF
--- a/sources/cli.swift
+++ b/sources/cli.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+func consumeArgument(flag: String, from arguments: inout ArraySlice<String>) -> String? {
+    if let argumentIndex = arguments.index(of: flag) {
+        let value = arguments.suffix(from: argumentIndex).dropFirst().joined(separator: " ")
+        if value.isEmpty {
+            exitWithUsage()
+        }
+
+        arguments = arguments.prefix(upTo: argumentIndex)
+        return value
+    }
+
+    return nil
+}
+
+func createUUID(from string: String) throws -> UUID {
+    if let uuid = UUID(uuidString: string) {
+        return uuid
+    }
+
+    throw CommandLineError.invalidUUID(string: string)
+}

--- a/sources/cli.swift
+++ b/sources/cli.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-func consumeArgument(flag: String, from arguments: inout ArraySlice<String>) -> String? {
-    guard let argumentIndex = arguments.index(of: flag) else {
+func consumeArgument(name: String, from arguments: inout ArraySlice<String>) -> String? {
+    guard let argumentIndex = arguments.index(of: name) else {
         return nil
     }
 

--- a/sources/cli.swift
+++ b/sources/cli.swift
@@ -1,17 +1,17 @@
 import Foundation
 
 func consumeArgument(flag: String, from arguments: inout ArraySlice<String>) -> String? {
-    if let argumentIndex = arguments.index(of: flag) {
-        let value = arguments.suffix(from: argumentIndex).dropFirst().joined(separator: " ")
-        if value.isEmpty {
-            exitWithUsage()
-        }
-
-        arguments = arguments.prefix(upTo: argumentIndex)
-        return value
+    guard let argumentIndex = arguments.index(of: flag) else {
+        return nil
     }
 
-    return nil
+    let value = arguments.suffix(from: argumentIndex).dropFirst().joined(separator: " ")
+    if value.isEmpty {
+        exitWithUsage()
+    }
+
+    arguments = arguments.prefix(upTo: argumentIndex)
+    return value
 }
 
 func createUUID(from string: String) throws -> UUID {

--- a/sources/errors.swift
+++ b/sources/errors.swift
@@ -1,8 +1,22 @@
+import Foundation
+
+enum CommandLineError: Error, CustomStringConvertible {
+    case invalidUUID(string: String)
+
+    var description: String {
+        switch self {
+        case .invalidUUID(let string):
+            return "The UUID '\(string)' is invalid"
+        }
+    }
+}
+
 enum SimulatorFetchError: Error, CustomStringConvertible {
     case simctlFailed
     case failedToReadOutput
     case noBootedSimulators
     case noMatchingSimulators(name: String)
+    case noMatchingUDID(udid: UUID)
 
     var description: String {
         switch self {
@@ -14,6 +28,8 @@ enum SimulatorFetchError: Error, CustomStringConvertible {
             return "No simulators are currently booted"
         case .noMatchingSimulators(let name):
             return "No booted simulators named '\(name)'"
+        case .noMatchingUDID(let udid):
+            return "No booted simulators with udid: \(udid.uuidString)"
         }
     }
 }

--- a/sources/main.swift
+++ b/sources/main.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 var arguments = CommandLine.arguments.dropFirst()
-let deviceUUID = try consumeArgument(flag: "-u", from: &arguments).map(createUUID)
-let deviceName = consumeArgument(flag: "-s", from: &arguments)
+let deviceUUID = try consumeArgument(name: "-u", from: &arguments).map(createUUID)
+let deviceName = consumeArgument(name: "-s", from: &arguments)
 
 guard let flag = arguments.popFirst() else {
     exitWithUsage()

--- a/sources/simulators.swift
+++ b/sources/simulators.swift
@@ -12,7 +12,7 @@ struct Simulators: Codable {
 struct Simulator: Codable {
     private let state: String
     fileprivate let name: String
-    let udid: String
+    let udid: UUID
 
     var isBooted: Bool {
         return self.state == "Booted"
@@ -23,6 +23,15 @@ func getSimulators(named name: String, from simulators: [Simulator]) throws -> [
     let matchingSimulators = simulators.filter { $0.name.lowercased() == name.lowercased() }
     if matchingSimulators.isEmpty {
         throw SimulatorFetchError.noMatchingSimulators(name: name)
+    }
+
+    return matchingSimulators
+}
+
+func getSimulators(with uuid: UUID, from simulators: [Simulator]) throws -> [Simulator] {
+    let matchingSimulators = simulators.filter { $0.udid == uuid }
+    if matchingSimulators.isEmpty {
+        throw SimulatorFetchError.noMatchingUDID(udid: uuid)
     }
 
     return matchingSimulators

--- a/sources/stderr.swift
+++ b/sources/stderr.swift
@@ -13,6 +13,7 @@ func exitWithUsage(error: String? = nil) -> Never {
         print(error, terminator: "\n\n", to: &stderrStream)
     }
 
-    print("Usage: set-simulator-location [-c 0 0|-q San Francisco] [-s Simulator Name]", to: &stderrStream)
+    print("Usage: set-simulator-location [-c 0 0|-q San Francisco] [-s Simulator Name|-u Simulator udid]",
+          to: &stderrStream)
     exit(EXIT_FAILURE)
 }


### PR DESCRIPTION
Previously we supported passing the name of a specific simulator. This
adds support for passing a udid directly as well.