### PR TITLE
Build with 4.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:4.2
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
Without this we were still building with `-swift-version 4`